### PR TITLE
Fix typo + execName

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Visual Studio Code extenstion for Nand2Tetris Language support.
 
 3. **Auto load the `.tst` script to check your `.asm` program**
 
-4. **Quckly `compress` the course source to a `zip` that can easily commit**
+4. **Quickly `compress` the course source to a `zip` that can easily commit**
 
 5. **Auto add necessary files like `prog.txt` into `zip` when compress the source**
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -88,7 +88,7 @@ export class Commands implements vscode.Disposable {
 
         const filePath = parse(this.document.fileName);
         const fileName = filePath.name + filePath.ext;
-        const execName = join(filePath.dir, filePath.name).replace(/ /g, "\" \"").replace(/\\/g, "/");
+        const execName = join(filePath.dir, filePath.name).replace(/\\/g, "/");
         let command: string;
         if (filePath.ext === ".hdl") {
             command = this.hardwareCmd + execName + ".tst";


### PR DESCRIPTION
Fixes #7 (incorrect execName) + a typo in the README.